### PR TITLE
No longer verify TLS to work with TLS self-signed TCP socket or containers lacking appropriate cert chains

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   docker:
     git: https://github.com/PercussiveElbow/docker-crystal.git
-    version: 0.0.1+git.commit.3020ef7214cb6b76fe3396dc86d6be8d5ff77243
+    version: 0.0.2+git.commit.4fa2f79986483aa8dfa7cb8c8b06014f6a20b381
 
   net_sample:
     git: https://github.com/PercussiveElbow/net_sample.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: docker-escape-tool
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - mil0 (mil0.io)
@@ -15,7 +15,6 @@ dependencies:
   net_sample:
     github: PercussiveElbow/net_sample.cr
     branch: master
-      
 # development_dependencies:
 #   ameba:
 #     github: crystal-ameba/ameba

--- a/src/breakouts/socket/socket_breakout.cr
+++ b/src/breakouts/socket/socket_breakout.cr
@@ -19,7 +19,7 @@ end
 
 def setup_docker_client(socket,port) # unix socket seems tempermental - getting broken pipe exceptions. Quick fix is just to reinstantiate the client after each exec request
     if port > 0
-        client = Docker::Client.new(socket,port)
+        client = Docker::Client.new(socket,port,false)
     else
         client = Docker::Client.new(socket)
     end

--- a/src/checks/capability/capability_check.cr
+++ b/src/checks/capability/capability_check.cr
@@ -41,6 +41,7 @@ CAP_CONSTANTS = [
     "CAP_AUDIT_READ",       
 ]
 
+
 def capability_check
     section_banner("Capabilities Check")
     puts("==> Checking avaliable capabilities.")

--- a/src/checks/network_socket/network_socket_check.cr
+++ b/src/checks/network_socket/network_socket_check.cr
@@ -69,7 +69,7 @@ def check_for_docker_network_socket(path, port, tls)
         else
             client = HTTP::Client.new(uri)
         end
-        client = Docker::Client.new(path,port)
+        client = Docker::Client.new(path,port,false)
         client.list_containers()
         puts("•  Docker Daemon possibly found on #{return_path}".green)
         host_and_port


### PR DESCRIPTION
#18 No longer verify TLS on default HTTPS port to work with self-signed certs that we likely won't have access to in a container

Underlying library change here: https://github.com/PercussiveElbow/docker-crystal/commit/7fd898cfed244a873dab244582d85ab9646e2c15